### PR TITLE
feat: add Windows ARM64/Python 3.13 venv compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,190 @@ docker-compose logs -f
 docker-compose down
 ```
 
+## 🪟 Configuración para Windows (Desarrollo Local)
+
+### Prerrequisitos Windows
+
+1. **Python 3.11-3.13**
+   - Descargar desde: https://python.org/downloads/
+   - Durante instalación: ☑️ "Add Python to PATH"
+   - Verificar: `python --version` en PowerShell
+
+2. **PostgreSQL**
+   - Descargar desde: https://postgresql.org/download/windows/
+   - Durante instalación, recordar usuario/contraseña
+   - Verificar: `psql --version` en PowerShell
+
+3. **Git** (opcional si ya tienes)
+   - Descargar desde: https://git-scm.com/download/win
+
+### Opción 1: Entorno Virtual (venv) - Recomendado
+
+```powershell
+# 1. Clonar el repositorio
+git clone <repository-url>
+cd mgen-backend
+
+# 2. Crear entorno virtual
+python -m venv venv
+
+# 3. Activar entorno virtual (PowerShell)
+.\venv\Scripts\activate
+
+# 4. Actualizar pip
+python -m pip install --upgrade pip
+
+# 5. Instalar dependencias
+# ⚠️ Si tienes problemas con psycopg2-binary en Windows ARM64/Python 3.13:
+pip install -r requirements-dev.txt  # Para Windows con problemas de compatibilidad
+# ✅ Para otros casos (Docker, Linux, macOS):
+pip install -r requirements.txt      # Archivo oficial
+
+# 6. Configurar variables de entorno
+# Crear archivo .env basado en env.example
+copy env.example .env
+# Editar .env con tus credenciales de PostgreSQL
+# IMPORTANTE: La app cargará automáticamente las variables del .env
+
+# 7. Ejecutar migraciones
+alembic upgrade head
+
+# 8. Levantar la aplicación
+uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+```
+
+### Opción 2: Conda Environment
+
+```powershell
+# 1. Clonar el repositorio
+git clone <repository-url>
+cd mgen-backend
+
+# 2. Crear ambiente conda
+conda create -n mgen-backend python=3.11
+conda activate mgen-backend
+
+# 3. Instalar dependencias
+# ⚠️ Si tienes problemas con psycopg2-binary en Windows ARM64/Python 3.13:
+pip install -r requirements-dev.txt  # Para Windows con problemas de compatibilidad
+# ✅ Para otros casos:
+pip install -r requirements.txt      # Archivo oficial
+
+# 4. Configurar variables de entorno
+copy env.example .env
+# Editar .env con tus credenciales
+
+# 5. Ejecutar migraciones
+alembic upgrade head
+
+# 6. Levantar la aplicación
+uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+```
+
+### Problemas Comunes en Windows
+
+### Problemas Comunes en Windows
+
+#### ❌ Error: No se pueden instalar dependencias (Python 3.13 + ARM64)
+```powershell
+# Síntoma
+ERROR: Microsoft Visual C++ 14.0 or greater is required
+
+# Solución: Usar archivo específico para Windows
+pip install -r requirements-dev.txt
+```
+
+#### ❌ PostgreSQL no se conecta
+```powershell
+# Verificar si PostgreSQL está corriendo
+python -c "import socket; s = socket.socket(); print('PostgreSQL OK' if s.connect_ex(('localhost', 5432)) == 0 else 'PostgreSQL no accesible'); s.close()"
+
+# Si no está corriendo, iniciar PostgreSQL (Windows Service)
+Start-Service postgresql-x64-15  # Ajustar versión según instalación
+```
+
+### Archivos de dependencias
+
+| Archivo | Uso | Descripción |
+|---------|-----|-------------|
+| `requirements.txt` | **Oficial** | Docker, Linux, macOS, Producción, CI/CD |
+| `requirements-dev.txt` | **Windows local** | Solo para desarrollo en Windows con problemas de compatibilidad |
+
+### Configuración de .env para Windows
+
+```env
+# Database Configuration
+DATABASE_URL=postgresql+pg8000://postgres:TU_PASSWORD@localhost:5432/donations_db
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=TU_PASSWORD
+POSTGRES_DB=donations_db
+
+# Database Pool Configuration (opcional)
+DB_POOL_SIZE=10
+DB_MAX_OVERFLOW=20
+SQL_ECHO=false
+
+# Application Configuration
+ENVIRONMENT=development
+DEBUG=true
+LOG_LEVEL=INFO
+```
+
+### Comandos útiles para desarrollo
+
+```powershell
+# Activar entorno virtual
+.\venv\Scripts\activate
+
+# Desactivar entorno virtual
+deactivate
+
+# Ver paquetes instalados
+pip list
+
+# Actualizar requirements.txt
+pip freeze > requirements.txt
+
+# Ejecutar tests
+pytest
+
+# Ver logs de la aplicación
+# Los logs aparecerán en la consola al ejecutar uvicorn
+```
+
+### URLs de desarrollo local
+
+Una vez levantada la aplicación:
+- **API**: http://localhost:8000
+- **Documentación**: http://localhost:8000/docs
+- **Health Check**: http://localhost:8000/health
+
+### 🐍 Comparación: venv vs Conda
+
+| Característica | venv | Conda |
+|---------------|------|-------|
+| **Incluido con Python** | ✅ Sí | ❌ Instalación separada |
+| **Gestión de dependencias** | pip solamente | pip + conda |
+| **Paquetes binarios** | Limitado | Excelente |
+| **Peso** | Ligero (~5-10 MB) | Pesado (~500 MB-3 GB) |
+| **Velocidad** | Rápido | Más lento |
+| **Gestión de versiones Python** | ❌ No | ✅ Sí |
+| **Recomendado para** | Proyectos Python simples | Data Science, ML |
+
+#### ¿Cuándo usar cada uno?
+
+**Usar venv si:**
+- Es tu primer proyecto Python
+- Solo usas paquetes de PyPI
+- Prefieres herramientas simples
+- Espacio limitado en disco
+
+**Usar conda si:**
+- Trabajas con data science/ML
+- Necesitas paquetes científicos (numpy, pandas, etc.)
+- Trabajas con múltiples versiones de Python
+- Ya tienes Anaconda instalado
+
 ## 📊 Servicios y Puertos
 
 | Servicio | Puerto | URL | Descripción |
@@ -56,6 +240,8 @@ Nota: Cambia estas credenciales en producción mediante variables de entorno o s
 
 ## 🛠️ Desarrollo
 
+> **💡 Nota**: Para desarrollo en Windows, consulta la sección [Configuración para Windows](#-configuración-para-windows-desarrollo-local) arriba.
+
 ```bash
 # Instalar dependencias localmente
 pip install -r requirements.txt
@@ -66,6 +252,12 @@ alembic upgrade head
 # Desarrollo local (sin Docker)
 uvicorn app.main:app --reload --port 8000
 ```
+
+### Dependencias por plataforma
+
+- **Linux/macOS + Docker**: Usa `requirements.txt` original con `psycopg2-binary`
+- **Windows (desarrollo local)**: Usa `requirements.txt` modificado con `pg8000`
+- **Python 3.13 + ARM64**: Requiere `pg8000` por compatibilidad
 
 ### Herramientas locales
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ copy env.example .env
 
 # 7. Ejecutar migraciones
 alembic upgrade head
+# Si da error "tabla ya existe", ejecutar: alembic stamp head
 
 # 8. Levantar la aplicación
 uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
@@ -125,6 +126,15 @@ python -c "import socket; s = socket.socket(); print('PostgreSQL OK' if s.connec
 
 # Si no está corriendo, iniciar PostgreSQL (Windows Service)
 Start-Service postgresql-x64-15  # Ajustar versión según instalación
+```
+
+#### ❌ Error en migraciones: "tabla ya existe"
+```powershell
+# Síntoma
+ProgrammingError: la relación «status_catalog» ya existe
+
+# Solución: Sincronizar Alembic con tablas existentes
+alembic stamp head
 ```
 
 ### Archivos de dependencias

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -5,6 +5,10 @@ from alembic import context
 import os
 import sys
 
+# Load environment variables from .env file
+from dotenv import load_dotenv
+load_dotenv()
+
 # Add the project root to Python path
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 

--- a/app/infrastructure/database/database.py
+++ b/app/infrastructure/database/database.py
@@ -7,18 +7,15 @@ from sqlalchemy.orm import sessionmaker
 import os
 from typing import Generator
 
-# Database URL from environment
-DATABASE_URL = os.getenv(
-    "DATABASE_URL", 
-    "postgresql://postgres:postgres@localhost:5432/donations_db"
-)
+# Load DATABASE_URL from environment
+DATABASE_URL = os.getenv("DATABASE_URL")
 
 # Create SQLAlchemy engine
 engine = create_engine(
     DATABASE_URL,
     pool_pre_ping=True,
-    pool_size=10,
-    max_overflow=20,
+    pool_size=int(os.getenv("DB_POOL_SIZE", "10")),
+    max_overflow=int(os.getenv("DB_MAX_OVERFLOW", "20")),
     echo=os.getenv("SQL_ECHO", "false").lower() == "true"
 )
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,10 @@
 """
 Main FastAPI application with hexagonal architecture
 """
+# Load environment variables first
+from dotenv import load_dotenv
+load_dotenv()
+
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse

--- a/env.example
+++ b/env.example
@@ -4,6 +4,11 @@ POSTGRES_USER=your_db_user
 POSTGRES_PASSWORD=your_secure_password
 POSTGRES_DB=donations_db
 
+# Database Connection Pool Settings
+DB_POOL_SIZE=10
+DB_MAX_OVERFLOW=20
+SQL_ECHO=false
+
 # RabbitMQ Configuration
 RABBITMQ_URL=amqp://username:password@localhost:5672/
 RABBITMQ_DEFAULT_USER=your_rabbitmq_user

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,69 @@
+# ===============================================================================
+# REQUIREMENTS PARA DESARROLLO LOCAL EN WINDOWS
+# ===============================================================================
+# 
+# Este archivo es ÚNICAMENTE para desarrollo local en Windows con problemas
+# de compatibilidad (Python 3.13 + ARM64, falta de herramientas de compilación)
+# 
+# PARA CUALQUIER OTRO ENTORNO USA: requirements.txt
+# - Docker (local o en la nube)  
+# - Linux/macOS
+# - Servidores de producción
+# - CI/CD pipelines
+# 
+# ===============================================================================
+
+# === DIFERENCIAS PRINCIPALES CON requirements.txt ===
+# 1. pg8000 en lugar de psycopg2-binary (no compila en Windows ARM64)
+# 2. uvicorn sin [standard] (httptools no compila)  
+# 3. Versiones actualizadas para compatibilidad con Python 3.13
+
+# === DEPENDENCIAS CORE ===
+fastapi==0.104.1
+uvicorn==0.24.0  # Sin [standard] para evitar problemas de compilación
+
+# Dependencias manuales de uvicorn
+click==8.1.7
+h11==0.14.0
+
+# === BASE DE DATOS ===
+sqlalchemy==2.0.43  # Versión actualizada compatible con Python 3.13
+pg8000==1.31.5      # Reemplaza psycopg2-binary
+alembic==1.13.0
+
+# === VALIDACIÓN Y SERIALIZACIÓN ===
+pydantic>=2.10.0  # Versión más reciente compatible con Python 3.13
+pydantic[email]>=2.10.0
+email-validator==2.1.0
+
+# === AUTENTICACIÓN Y SEGURIDAD ===
+python-jose[cryptography]==3.3.0
+passlib[bcrypt]==1.7.4
+
+# === UTILIDADES ===
+python-dotenv==1.0.0
+python-multipart==0.0.6
+
+# === LOGGING ===
+structlog==23.2.0
+python-json-logger==2.0.7
+
+# === TESTING ===
+pytest==7.4.3
+pytest-asyncio==0.21.1
+httpx==0.25.2
+
+# === MONITORING ===
+prometheus-client==0.19.0
+
+# === MESSAGING ===
+pika==1.3.2
+celery==5.3.4
+
+# ===============================================================================
+# INSTALACIÓN:
+# pip install -r requirements-dev.txt
+# 
+# CONFIGURACIÓN DE BD:
+# DATABASE_URL=postgresql+pg8000://postgres:password@localhost:5432/donations_db
+# ===============================================================================


### PR DESCRIPTION
- Add requirements-dev.txt for Windows development with pg8000 driver
- Update main.py to auto-load .env variables
- Remove hardcoded values from database.py configuration
- Update README.md with enhanced Windows setup documentation
- Update env.example with additional database pool configurations

This enables development using venv on Windows ARM64 with Python 3.13 where psycopg2-binary compilation fails.